### PR TITLE
remove absolute path from extension

### DIFF
--- a/BezierSurgeon.roboFontExt/info.plist
+++ b/BezierSurgeon.roboFontExt/info.plist
@@ -20,7 +20,7 @@
 	<key>launchAtStartUp</key>
 	<true/>
 	<key>mainScript</key>
-	<string>/Users/connordavenport/Dropbox (Personal)/Typefaces/Scripts/ObtuseBois/BezierSurgeon/lib/BezierSurgeon.py</string>
+	<string>BezierSurgeon.py</string>
 	<key>name</key>
 	<string>Bezier Surgeon</string>
 	<key>requiresVersionMajor</key>

--- a/buildExtension.py
+++ b/buildExtension.py
@@ -15,7 +15,7 @@ B.name = "Bezier Surgeon"
 B.version = "0.1"
 B.developer = "Connor Davenport"
 B.developerURL = 'http://www.connordavenport.com/'
-B.mainScript = os.path.join(libPath, "BezierSurgeon.py")
+B.mainScript = "BezierSurgeon.py"
 B.launchAtStartUp = True
 B.addToMenu = [
     {


### PR DESCRIPTION
Cool extension!

I got an error message when trying to install it because it had an absolute path to the file in the dropbox folder on your machine. 

I _think_ you can just include the filename and it should work.